### PR TITLE
Adding method to recover if specific error happens

### DIFF
--- a/MJSwiftCore/Classes/Future/Future+Functional.swift
+++ b/MJSwiftCore/Classes/Future/Future+Functional.swift
@@ -109,7 +109,7 @@ public extension Future {
     ///    - executor: An optional executor to execute the closure.
     ///    - closure: The recover closure
     /// - Returns: A chained future
-    public func recoverIf<E:Error>(_ errorType: E.Type, _ executor: Executor = DirectExecutor(), _ closure: @escaping (E) throws -> Future<T>) -> Future<T> {
+    public func recover<E:Error>(if errorType: E.Type, _ executor: Executor = DirectExecutor(), _ closure: @escaping (E) throws -> Future<T>) -> Future<T> {
         return Future { resolver in
             resolve(success: {value in
                 executor.submit { resolver.set(value) }

--- a/MJSwiftCore/Classes/Future/Observable+Functional.swift
+++ b/MJSwiftCore/Classes/Future/Observable+Functional.swift
@@ -102,6 +102,34 @@ public extension Observable {
         }
     }
     
+    /// Intercepts the error (if available) and returns a new observable of type T
+    ///
+    /// - Parameters:
+    ///    - error: The error type to recover only.
+    ///    - executor: An optional executor to execute the closure.
+    ///    - closure: The recover closure
+    /// - Returns: A chained observable
+    public func recover<E:Error>(if errorType: E.Type, _ executor: Executor = DirectExecutor(), _ closure: @escaping (E) throws -> Observable<T>) -> Observable<T> {
+        return Observable(parent: self) { resolver in
+            resolve(success: {value in
+                executor.submit { resolver.set(value) }
+            }, failure: { error in
+                executor.submit {
+                    switch error {
+                    case let error as E:
+                        do {
+                            resolver.set(try closure(error))
+                        } catch let error {
+                            resolver.set(error)
+                        }
+                    default:
+                        resolver.set(error)
+                    }
+                }
+            })
+        }
+    }
+    
     /// Notifies completion of the observable in both success or failure state.
     ///
     /// - Parameters:


### PR DESCRIPTION
We currently have a `recover` method that gives the opportunity to the user to check the incoming error and recover it to a success full state or to another error type.

The new `recoverIf` method brings a more specific approach, where the error type can be passed as a parameter and the closure will be called with a casted error if the error type matches. 