### PR TITLE
Repositories now must support DefaultOperation

### DIFF
--- a/Example/MJSwiftCore/Core/DI/ItemAssembly.swift
+++ b/Example/MJSwiftCore/Core/DI/ItemAssembly.swift
@@ -25,11 +25,11 @@ class ItemAssembly: Assembly {
         }
         
         // Storage (Realm)
-//        let storageDataSource = RealmDataSource(realmHandler: container.resolve(RealmHandler.self)!,
-//                                                toEntityMapper: RealmItemToItemEntityMapper(),
-//                                                toRealmMapper: ItemEntityToRealmItemMapper())
+        let storageDataSource = RealmDataSource(realmHandler: container.resolve(RealmHandler.self)!,
+                                                toEntityMapper: RealmItemToItemEntityMapper(),
+                                                toRealmMapper: ItemEntityToRealmItemMapper())
         // Storage (In-Memory)
-        let storageDataSource = InMemoryDataSource<ItemEntity>()
+//        let storageDataSource = InMemoryDataSource<ItemEntity>()
 
         // Storage (UserDefaults)
 //        let userDefaultsDataSource = DeviceStorageDataSource<Data>(UserDefaults.standard, prefix: "ItemEntity")

--- a/MJSwiftCore/Classes/Repository/CacheRepository.swift
+++ b/MJSwiftCore/Classes/Repository/CacheRepository.swift
@@ -168,7 +168,7 @@ public class CacheRepository<M,C,T> : GetRepository, PutRepository, DeleteReposi
     public func deleteAll(_ query: Query, operation: Operation) -> Future<Void> {
         switch operation {
         case is DefaultOperation:
-            return delete(query, operation: MainSyncOperation())
+            return deleteAll(query, operation: MainSyncOperation())
         case is MainOperation:
             return main.deleteAll(query)
         case is CacheOperation:

--- a/MJSwiftCore/Classes/Repository/Operation.swift
+++ b/MJSwiftCore/Classes/Repository/Operation.swift
@@ -17,11 +17,13 @@
 import Foundation
 
 ///
-/// An operation defines an abstraction on how data must be fetched (to which DataSource<T> a query must be forwarded).
+/// An operation defines an abstraction on how data must be fetched (how and to which data source a query must be forwarded).
 ///
 public protocol Operation { }
 
-/// The default operation.
+///
+/// The default operation. All repository implementations must accept this operation.
+///
 public class DefaultOperation : Operation {
     public init() { }
 }

--- a/MJSwiftCore/Classes/Repository/RetryRepository.swift
+++ b/MJSwiftCore/Classes/Repository/RetryRepository.swift
@@ -75,6 +75,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     
     public func get(_ query: Query, operation: Operation) -> Future<T> {
         switch operation {
+        case is DefaultOperation:
+            return get(query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.get(query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {
@@ -90,6 +92,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     
     public func getAll(_ query: Query, operation: Operation) -> Future<[T]> {
         switch operation {
+        case is DefaultOperation:
+            return getAll(query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.getAll(query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {
@@ -106,6 +110,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     @discardableResult
     public func put(_ value: T?, in query: Query, operation: Operation) -> Future<T> {
         switch operation {
+        case is DefaultOperation:
+            return put(value, in: query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.put(value, in: query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {
@@ -122,6 +128,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     @discardableResult
     public func putAll(_ array: [T], in query: Query, operation: Operation) -> Future<[T]> {
         switch operation {
+        case is DefaultOperation:
+            return putAll(array, in: query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.putAll(array, in: query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {
@@ -138,6 +146,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     @discardableResult
     public func delete(_ query: Query, operation: Operation) -> Future<Void> {
         switch operation {
+        case is DefaultOperation:
+            return delete(query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.delete(query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {
@@ -154,6 +164,8 @@ public class RetryRepository <R,T> : GetRepository, PutRepository, DeleteReposit
     @discardableResult
     public func deleteAll(_ query: Query, operation: Operation) -> Future<Void> {
         switch operation {
+        case is DefaultOperation:
+            return deleteAll(query, operation: RetryOperation(DefaultOperation()))
         case let retryOp as RetryOperation:
             return repository.deleteAll(query, operation: retryOp.operation).recover { error in
                 if retryOp.canRetry(error) {

--- a/MJSwiftCore/Classes/Repository/VoidRepository.swift
+++ b/MJSwiftCore/Classes/Repository/VoidRepository.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 Mobile Jazz SL
+// Copyright 2018 Mobile Jazz SL
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added support of `DefaultOperation` to:

- `CacheRepository` <-- **This is the relevant and significant change**
- `RetryRepository` <-- This is just a side change to be consistent