### PR TITLE
adding withMapper methods on Get and Put data source and Repository

### DIFF
--- a/Harmony/Classes/Repository/DataSourceMapper.swift
+++ b/Harmony/Classes/Repository/DataSourceMapper.swift
@@ -48,6 +48,12 @@ public class GetDataSourceMapper <D: GetDataSource,In,Out> : GetDataSource where
     }
 }
 
+extension GetDataSource {
+    func withMapping<K>(_ toOutMapper: Mapper<T,K>) -> GetDataSourceMapper<Self,T,K> {
+        return GetDataSourceMapper(dataSource: self, toOutMapper: toOutMapper)
+    }
+}
+
 ///
 /// This data source uses mappers to map objects and redirects them to the contained data source, acting as a simple "translator".
 ///
@@ -87,6 +93,12 @@ public class PutDataSourceMapper <D: PutDataSource,In,Out> : PutDataSource where
     @discardableResult
     public func putAll(_ array: [Out], in query: Query) -> Future<[Out]> {
         return Future { dataSource.putAll(try toInMapper.map(array), in: query).map { try self.toOutMapper.map($0) } }
+    }
+}
+
+extension PutDataSource {
+    func withMapping<K>(in toInMapper: Mapper<K,T>, out toOutMapper: Mapper<T,K>) -> PutDataSourceMapper<Self,T,K> {
+        return PutDataSourceMapper(dataSource: self, toInMapper: toInMapper, toOutMapper: toOutMapper)
     }
 }
 

--- a/Harmony/Classes/Repository/RepositoryMapper.swift
+++ b/Harmony/Classes/Repository/RepositoryMapper.swift
@@ -48,6 +48,12 @@ public class GetRepositoryMapper <R: GetRepository,In,Out> : GetRepository where
     }
 }
 
+extension GetRepository {
+    func withMapping<K>(_ toOutMapper: Mapper<T,K>) -> GetRepositoryMapper<Self,T,K> {
+        return GetRepositoryMapper(repository: self, toOutMapper: toOutMapper)
+    }
+}
+
 ///
 /// This repository uses mappers to map objects and redirects them to the contained repository, acting as a simple "translator".
 ///
@@ -89,6 +95,12 @@ public class PutRepositoryMapper <R: PutRepository,Out,In> : PutRepository where
         return Future {
             return repository.putAll(try toInMapper.map(array), in: query, operation: operation).map { try self.toOutMapper.map($0) }
         }
+    }
+}
+
+extension PutRepository {
+    func withMapping<K>(in toInMapper: Mapper<K,T>, out toOutMapper: Mapper<T,K>) -> PutRepositoryMapper<Self,T,K> {
+        return PutRepositoryMapper(repository: self, toInMapper: toInMapper, toOutMapper: toOutMapper)
     }
 }
 


### PR DESCRIPTION
Hi folks,

I've added the discussed `withMapping(...)` extension methods in:

- `GetDataSource`
- `PutDataSource`
- `GetRepository`
- `PutRepository`

(Delete is not needed as it is not using Generics)

The main problem here is how to add the `withMapping(...)` method on the data source and repository implementations that implement both `Get` and `Put` interfaces. I don't see a way to do it rather than manually add the `withMapping(...)` in all repository & datasource implementations.

Any idea here?