### PR TITLE
Conditionally compile testing utilities

### DIFF
--- a/Harmony/Classes/Testing/BoolObjectMother.swift
+++ b/Harmony/Classes/Testing/BoolObjectMother.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +23,4 @@ import Foundation
 func randomBool() -> Bool {
     return Int.random(in: 0...1) != 0
 }
+#endif

--- a/Harmony/Classes/Testing/DoubleObjectMother.swift
+++ b/Harmony/Classes/Testing/DoubleObjectMother.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +23,4 @@ import Foundation
 func anyDouble(minValue: Double = -32000, maxValue: Double = 32000) -> Double {
     return Double.random(in: minValue...maxValue)
 }
+#endif

--- a/Harmony/Classes/Testing/ErrorObjectMother.swift
+++ b/Harmony/Classes/Testing/ErrorObjectMother.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#if DEBUG
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +22,4 @@ import Foundation
 func anyError() -> Error {
     CoreError.Failed()
 }
+#endif

--- a/Harmony/Classes/Testing/IntegerObjectModel.swift
+++ b/Harmony/Classes/Testing/IntegerObjectModel.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +23,4 @@ import Foundation
 func anyInt(minValue: Int = -32000, maxValue: Int = 32000) -> Int {
     return Int.random(in: minValue...maxValue)
 }
+#endif

--- a/Harmony/Classes/Testing/MockInteractorDelete.swift
+++ b/Harmony/Classes/Testing/MockInteractorDelete.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 public extension Interactor {
     
     class MockDeleteByQuery: DeleteByQuery {
@@ -181,3 +183,4 @@ public extension Interactor {
         }
     }
 }
+#endif

--- a/Harmony/Classes/Testing/MockInteractorGet.swift
+++ b/Harmony/Classes/Testing/MockInteractorGet.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 public extension Interactor {
     
     class MockGetByQuery<T>: GetByQuery<T> {
@@ -178,3 +180,4 @@ public extension Interactor {
         }
     }
 }
+#endif

--- a/Harmony/Classes/Testing/MockInteractorPut.swift
+++ b/Harmony/Classes/Testing/MockInteractorPut.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 public extension Interactor {
 
     class MockPutByQuery<T>: PutByQuery<T> {
@@ -190,3 +192,4 @@ public extension Interactor {
         }
     }
 }
+#endif

--- a/Harmony/Classes/Testing/StringObjectMother.swift
+++ b/Harmony/Classes/Testing/StringObjectMother.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +23,4 @@ import Foundation
 func anyString() -> String {
     "test-string"
 }
+#endif

--- a/Harmony/Classes/Testing/TestUtils.swift
+++ b/Harmony/Classes/Testing/TestUtils.swift
@@ -16,7 +16,7 @@
 
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
-
+#if DEBUG
 enum TestUtils<T> {
     static func result(expectedResult: Result<T, Error>) -> Future<T> {
         switch expectedResult {
@@ -27,3 +27,4 @@ enum TestUtils<T> {
         }
     }
 }
+#endif

--- a/Harmony/Classes/Testing/UUIDObjectMother.swift
+++ b/Harmony/Classes/Testing/UUIDObjectMother.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#if DEBUG
+
 import Foundation
 
 /* These functions are internal to only be retrieved using '@testable import Harmony'. */
@@ -21,3 +23,4 @@ import Foundation
 func anyUUID() -> UUID {
     UUID()
 }
+#endif


### PR DESCRIPTION
The purpose of this change is to avoid including testing-related symbols in archives with get built using the RELEASE configuration.