### PR TITLE
IOS-1859 :: Feature Internal :: Add RW Testing Outcome in Harmony Swift

### DIFF
--- a/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony.xcodeproj/project.pbxproj
@@ -102,6 +102,16 @@
 		59B7AA1B27A83966001F5D8F /* KeychainGetInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B7AA1627A83966001F5D8F /* KeychainGetInteractor.swift */; };
 		59B7AA1C27A83966001F5D8F /* SecureKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B7AA1727A83966001F5D8F /* SecureKey.swift */; };
 		59E5191427A934B400A18D72 /* Harmony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59B7A81227A827F6001F5D8F /* Harmony.framework */; };
+		D2067A3A285C5F8000A1047E /* DataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A39285C5F8000A1047E /* DataSourceSpy.swift */; };
+		D2067A3B285C5F8000A1047E /* DataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A39285C5F8000A1047E /* DataSourceSpy.swift */; };
+		D2067A3D285C600B00A1047E /* RepositorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A3C285C600B00A1047E /* RepositorySpy.swift */; };
+		D2067A3E285C600B00A1047E /* RepositorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A3C285C600B00A1047E /* RepositorySpy.swift */; };
+		D2067A40285C618600A1047E /* CacheRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A3F285C618600A1047E /* CacheRepositoryTests.swift */; };
+		D2067A43285C61DD00A1047E /* MockObjectValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A41285C61CE00A1047E /* MockObjectValidation.swift */; };
+		D2067A44285C61DD00A1047E /* MockObjectValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A41285C61CE00A1047E /* MockObjectValidation.swift */; };
+		D2067A47285C640300A1047E /* Number+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A45285C628D00A1047E /* Number+Extensions.swift */; };
+		D2067A48285C640500A1047E /* Number+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A45285C628D00A1047E /* Number+Extensions.swift */; };
+		D2067A4A285C64AD00A1047E /* InMemoryDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2067A49285C64AD00A1047E /* InMemoryDataSourceTests.swift */; };
 		D28C13F3285B090500E4F2CA /* FutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28C13F2285B090500E4F2CA /* FutureTests.swift */; };
 		D2D2163627AC280A00A104B8 /* LinkRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B7A85927A82971001F5D8F /* LinkRecognizer.swift */; };
 		D2D2163727AC280A00A104B8 /* Future+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B7A86B27A82971001F5D8F /* Future+Time.swift */; };
@@ -598,6 +608,12 @@
 		59E5192127A9462600A18D72 /* MockInteractorDelete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInteractorDelete.swift; sourceTree = "<group>"; };
 		59E5192227A9462F00A18D72 /* StringObjectMother.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringObjectMother.swift; sourceTree = "<group>"; };
 		59E5192327A9463D00A18D72 /* UUIDObjectMother.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDObjectMother.swift; sourceTree = "<group>"; };
+		D2067A39285C5F8000A1047E /* DataSourceSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceSpy.swift; sourceTree = "<group>"; };
+		D2067A3C285C600B00A1047E /* RepositorySpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySpy.swift; sourceTree = "<group>"; };
+		D2067A3F285C618600A1047E /* CacheRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheRepositoryTests.swift; sourceTree = "<group>"; };
+		D2067A41285C61CE00A1047E /* MockObjectValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockObjectValidation.swift; sourceTree = "<group>"; };
+		D2067A45285C628D00A1047E /* Number+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Number+Extensions.swift"; sourceTree = "<group>"; };
+		D2067A49285C64AD00A1047E /* InMemoryDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryDataSourceTests.swift; sourceTree = "<group>"; };
 		D28C13F2285B090500E4F2CA /* FutureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
 		D2D2168E27AC280A00A104B8 /* Harmony.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Harmony.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2D216A227AC291200A104B8 /* HarmonyTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HarmonyTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -765,6 +781,8 @@
 			isa = PBXGroup;
 			children = (
 				D28C13F2285B090500E4F2CA /* FutureTests.swift */,
+				D2067A3F285C618600A1047E /* CacheRepositoryTests.swift */,
+				D2067A49285C64AD00A1047E /* InMemoryDataSourceTests.swift */,
 			);
 			path = HarmonyTests;
 			sourceTree = "<group>";
@@ -1338,6 +1356,7 @@
 				59B7A85E27A82971001F5D8F /* JSONDecoding.swift */,
 				59B7A85F27A82971001F5D8F /* Data+Extensions.swift */,
 				59B7A85727A82971001F5D8F /* String+Extensions.swift */,
+				D2067A45285C628D00A1047E /* Number+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1385,6 +1404,7 @@
 			isa = PBXGroup;
 			children = (
 				59881E7B27A9DC9500D92121 /* TestUtils.swift */,
+				D2067A38285C5F6E00A1047E /* Data */,
 				59E5191E27A9462100A18D72 /* Interactor */,
 				59E5191927A945F300A18D72 /* ObjectMother */,
 			);
@@ -1463,6 +1483,16 @@
 				59E5192027A9462600A18D72 /* MockInteractorPut.swift */,
 			);
 			path = Interactor;
+			sourceTree = "<group>";
+		};
+		D2067A38285C5F6E00A1047E /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				D2067A39285C5F8000A1047E /* DataSourceSpy.swift */,
+				D2067A3C285C600B00A1047E /* RepositorySpy.swift */,
+				D2067A41285C61CE00A1047E /* MockObjectValidation.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1678,6 +1708,7 @@
 				59B7A8B927A82971001F5D8F /* Future+Time.swift in Sources */,
 				59B7A89D27A82971001F5D8F /* DataSourceMapper.swift in Sources */,
 				59B7A8AF27A82971001F5D8F /* DeviceConsoleLogger.swift in Sources */,
+				D2067A47285C640300A1047E /* Number+Extensions.swift in Sources */,
 				59B7A89927A82971001F5D8F /* Mapper+NSCoding.swift in Sources */,
 				59B7A8AD27A82971001F5D8F /* JSONDecoding.swift in Sources */,
 				59B7A8C527A82971001F5D8F /* ExecutorFactory.swift in Sources */,
@@ -1761,7 +1792,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2067A40285C618600A1047E /* CacheRepositoryTests.swift in Sources */,
 				D28C13F3285B090500E4F2CA /* FutureTests.swift in Sources */,
+				D2067A4A285C64AD00A1047E /* InMemoryDataSourceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1771,8 +1804,11 @@
 			files = (
 				5932E95D27A9473400253261 /* MockInteractorDelete.swift in Sources */,
 				5932E95E27A9473400253261 /* MockInteractorGet.swift in Sources */,
+				D2067A3D285C600B00A1047E /* RepositorySpy.swift in Sources */,
 				5932E95F27A9473400253261 /* MockInteractorPut.swift in Sources */,
 				59881E7C27A9DC9500D92121 /* TestUtils.swift in Sources */,
+				D2067A43285C61DD00A1047E /* MockObjectValidation.swift in Sources */,
+				D2067A3A285C5F8000A1047E /* DataSourceSpy.swift in Sources */,
 				5932E95727A9472D00253261 /* UUIDObjectMother.swift in Sources */,
 				5932E95827A9472D00253261 /* BoolObjectMother.swift in Sources */,
 				5932E95927A9472D00253261 /* DoubleObjectMother.swift in Sources */,
@@ -1790,6 +1826,7 @@
 				D2D2163727AC280A00A104B8 /* Future+Time.swift in Sources */,
 				D2D2163827AC280A00A104B8 /* DataSourceMapper.swift in Sources */,
 				D2D2163927AC280A00A104B8 /* DeviceConsoleLogger.swift in Sources */,
+				D2067A48285C640500A1047E /* Number+Extensions.swift in Sources */,
 				D2D2163A27AC280A00A104B8 /* Mapper+NSCoding.swift in Sources */,
 				D2D2163B27AC280A00A104B8 /* JSONDecoding.swift in Sources */,
 				D2D2163C27AC280A00A104B8 /* ExecutorFactory.swift in Sources */,
@@ -1875,8 +1912,11 @@
 			files = (
 				D2D2169227AC291200A104B8 /* MockInteractorDelete.swift in Sources */,
 				D2D2169327AC291200A104B8 /* MockInteractorGet.swift in Sources */,
+				D2067A3E285C600B00A1047E /* RepositorySpy.swift in Sources */,
 				D2D2169427AC291200A104B8 /* MockInteractorPut.swift in Sources */,
 				D2D2169527AC291200A104B8 /* TestUtils.swift in Sources */,
+				D2067A44285C61DD00A1047E /* MockObjectValidation.swift in Sources */,
+				D2067A3B285C5F8000A1047E /* DataSourceSpy.swift in Sources */,
 				D2D2169627AC291200A104B8 /* UUIDObjectMother.swift in Sources */,
 				D2D2169727AC291200A104B8 /* BoolObjectMother.swift in Sources */,
 				D2D2169827AC291200A104B8 /* DoubleObjectMother.swift in Sources */,

--- a/Sources/Harmony/Common/Error/CoreError.swift
+++ b/Sources/Harmony/Common/Error/CoreError.swift
@@ -71,6 +71,12 @@ public struct CoreError {
             super.init(domain:CoreError.domain, code: 5, description: description)
         }
     }
+    
+    public class QueryNotSupported: ClassError {
+        public init(_ description: String = "Query not supported") {
+            super.init(domain:CoreError.domain, code: 6, description: description)
+        }
+    }
 }
 
 extension CoreError {

--- a/Sources/Harmony/Common/Extensions/Number+Extensions.swift
+++ b/Sources/Harmony/Common/Extensions/Number+Extensions.swift
@@ -1,0 +1,113 @@
+//
+// Copyright 2017 Mobile Jazz SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public extension Int {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Int {
+        return Int.random(in: Int.min...Int.max)
+    }
+}
+
+public extension Int8 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Int8 {
+        return Int8.random(in: Int8.min...Int8.max)
+    }
+}
+
+public extension Int16 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Int16 {
+        return Int16.random(in: Int16.min...Int16.max)
+    }
+}
+
+public extension Int32 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Int32 {
+        return Int32.random(in: Int32.min...Int32.max)
+    }
+}
+
+public extension Int64 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Int64 {
+        return Int64.random(in: Int64.min...Int64.max)
+    }
+}
+
+public extension UInt {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> UInt {
+        return UInt.random(in: UInt.min...UInt.max)
+    }
+}
+
+public extension UInt8 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> UInt8 {
+        return UInt8.random(in: UInt8.min...UInt8.max)
+    }
+}
+
+public extension UInt16 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> UInt16 {
+        return UInt16.random(in: UInt16.min...UInt16.max)
+    }
+}
+
+public extension UInt32 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> UInt32 {
+        return UInt32.random(in: UInt32.min...UInt32.max)
+    }
+}
+
+public extension UInt64 {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> UInt64 {
+        return UInt64.random(in: UInt64.min...UInt64.max)
+    }
+}
+
+public extension Float {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Float {
+        return Float.random(in: Float.leastNormalMagnitude...Float.greatestFiniteMagnitude)
+    }
+}
+
+public extension Double {
+    /// Returns a random value.
+    /// - Returns: A random value.
+    static func random() -> Double {
+        return Double.random(in: Double.leastNormalMagnitude...Double.greatestFiniteMagnitude)
+    }
+}

--- a/Sources/Harmony/Data/DataSource/InMemoryDataSource.swift
+++ b/Sources/Harmony/Data/DataSource/InMemoryDataSource.swift
@@ -31,7 +31,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             }
             return Future(value)
         default:
-            query.fatalError(.get, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
     
@@ -51,7 +51,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             }
             return Future(CoreError.NotFound())
         default:
-            query.fatalError(.getAll, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
     
@@ -65,7 +65,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             objects[query.key] = value
             return Future(value)
         default:
-            query.fatalError(.put, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
     
@@ -84,7 +84,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             arrays[query.key] = array
             return Future(array)
         default:
-            query.fatalError(.putAll, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
     
@@ -95,7 +95,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             objects[query.key] = nil
             return Future(Void())
         default:
-            query.fatalError(.delete, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
     
@@ -115,7 +115,7 @@ public class InMemoryDataSource<T> : GetDataSource, PutDataSource, DeleteDataSou
             arrays[query.key] = nil
             return Future(Void())
         default:
-            query.fatalError(.deleteAll, self)
+            return Future(CoreError.QueryNotSupported())
         }
     }
 }

--- a/Sources/HarmonyTesting/Data/DataSourceSpy.swift
+++ b/Sources/HarmonyTesting/Data/DataSourceSpy.swift
@@ -1,0 +1,136 @@
+//
+// Copyright 2022 Mobile Jazz SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import Harmony
+
+/// A GetDataSource spy that records all calls.
+public class GetDataSourceSpy <D: GetDataSource, T> : GetDataSource where D.T == T {
+    
+    public private(set) var getCalls: [Query] = []
+    public private(set) var getAllCalls: [Query] = []
+    
+    private let dataSoruce: D
+    
+    public init(_ dataSource: D) {
+        self.dataSoruce = dataSource
+    }
+    
+    public func get(_ query: Query) -> Future<T> {
+        getCalls.append(query)
+        return dataSoruce.get(query)
+    }
+    
+    public func getAll(_ query: Query) -> Future<[T]> {
+        getAllCalls.append(query)
+        return dataSoruce.getAll(query)
+    }
+}
+
+/// A PutDataSource spy that records all calls.
+public class PutDataSourceSpy <D: PutDataSource, T> : PutDataSource where D.T == T {
+    
+    public private(set) var putCalls: [(value: T?, query: Query)] = []
+    public private(set) var putAllCalls: [(array: [T], query: Query)] = []
+    
+    private let dataSoruce: D
+    
+    public init(_ dataSource: D) {
+        self.dataSoruce = dataSource
+    }
+    
+    public func put(_ value: T?, in query: Query) -> Future<T> {
+        putCalls.append((value, query))
+        return dataSoruce.put(value, in: query)
+    }
+    
+    public func putAll(_ array: [T], in query: Query) -> Future<[T]> {
+        putAllCalls.append((array, query))
+        return dataSoruce.putAll(array, in: query)
+    }
+}
+
+/// A DeleteDataSource spy that records all calls.
+public class DeleteDataSourceSpy <D: DeleteDataSource>: DeleteDataSource {
+    
+    public private(set) var deleteCalls: [Query] = []
+    public private(set) var deleteAllCalls: [Query] = []
+    
+    private let dataSoruce: D
+    
+    public init(_ dataSource: D) {
+        self.dataSoruce = dataSource
+    }
+    
+    public func delete(_ query: Query) -> Future<Void> {
+        deleteCalls.append(query)
+        return dataSoruce.delete(query)
+    }
+    
+    public func deleteAll(_ query: Query) -> Future<Void> {
+        deleteAllCalls.append(query)
+        return dataSoruce.deleteAll(query)
+    }
+}
+
+/// A DataSource spy that records all calls.
+public class DataSourceSpy <D,T> : GetDataSource, PutDataSource, DeleteDataSource where D:GetDataSource, D:PutDataSource, D:DeleteDataSource, D.T == T {
+    
+    public private(set) var getCalls: [Query] = []
+    public private(set) var getAllCalls: [Query] = []
+    
+    private let dataSoruce: D
+    
+    public init(_ dataSource: D) {
+        self.dataSoruce = dataSource
+    }
+    
+    public func get(_ query: Query) -> Future<T> {
+        getCalls.append(query)
+        return dataSoruce.get(query)
+    }
+    
+    public func getAll(_ query: Query) -> Future<[T]> {
+        getAllCalls.append(query)
+        return dataSoruce.getAll(query)
+    }
+    
+    public private(set) var putCalls: [(value: T?, query: Query)] = []
+    public private(set) var putAllCalls: [(array: [T], query: Query)] = []
+    
+    public func put(_ value: T?, in query: Query) -> Future<T> {
+        putCalls.append((value, query))
+        return dataSoruce.put(value, in: query)
+    }
+    
+    public func putAll(_ array: [T], in query: Query) -> Future<[T]> {
+        putAllCalls.append((array, query))
+        return dataSoruce.putAll(array, in: query)
+    }
+    
+    public private(set) var deleteCalls: [Query] = []
+    public private(set) var deleteAllCalls: [Query] = []
+    
+    public func delete(_ query: Query) -> Future<Void> {
+        deleteCalls.append(query)
+        return dataSoruce.delete(query)
+    }
+    
+    public func deleteAll(_ query: Query) -> Future<Void> {
+        deleteAllCalls.append(query)
+        return dataSoruce.deleteAll(query)
+    }
+}

--- a/Sources/HarmonyTesting/Data/MockObjectValidation.swift
+++ b/Sources/HarmonyTesting/Data/MockObjectValidation.swift
@@ -1,0 +1,32 @@
+//
+//  MockObjectValidation.swift
+//  HarmonyTests
+//
+//  Created by Joan Martin on 17/6/22.
+//
+
+import Foundation
+import Harmony
+
+/// Mock ObjectValidation implementation with custom return definition.
+public struct MockObjectValidation<T>: ObjectValidation {
+    public let objectValid: Bool
+    public let arrayValid: Bool
+    
+    /// Default initializer.
+    /// - Parameters:
+    ///   - objectValid: The bool value to return upon object validation. Default value is true.
+    ///   - arrayValid: The bool value to return upon array validation. Default value is true.
+    public init(objectValid: Bool = true, arrayValid: Bool = true) {
+        self.objectValid = objectValid
+        self.arrayValid = arrayValid
+    }
+    
+    public func isObjectValid<T>(_ object: T) -> Bool {
+        return objectValid
+    }
+    
+    public func isArrayValid<T>(_ objects: [T]) -> Bool {
+        return arrayValid
+    }
+}

--- a/Sources/HarmonyTesting/Data/RepositorySpy.swift
+++ b/Sources/HarmonyTesting/Data/RepositorySpy.swift
@@ -1,0 +1,136 @@
+//
+// Copyright 2022 Mobile Jazz SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import Harmony
+
+/// A GetRepository spy that records all calls.
+public class GetRepositorySpy <D: GetRepository, T> : GetRepository where D.T == T {
+        
+    public private(set) var getCalls: [(query: Query, operation: Harmony.Operation)] = []
+    public private(set) var getAllCalls: [(query: Query, operation: Harmony.Operation)] = []
+    
+    private let repository: D
+    
+    public init(_ dataSource: D) {
+        self.repository = dataSource
+    }
+    
+    public func get(_ query: Query, operation: Harmony.Operation) -> Future<T> {
+        getCalls.append((query, operation))
+        return repository.get(query, operation: operation)
+    }
+    
+    public func getAll(_ query: Query, operation: Harmony.Operation) -> Future<[T]> {
+        getAllCalls.append((query, operation))
+        return repository.getAll(query, operation: operation)
+    }
+}
+
+/// A PutRepository spy that records all calls.
+public class PutRepositorySpy <D: PutRepository, T> : PutRepository where D.T == T {
+        
+    public private(set) var putCalls: [(value: T?, query: Query, operation: Harmony.Operation)] = []
+    public private(set) var putAllCalls: [(array: [T], query: Query, operation: Harmony.Operation)] = []
+    
+    private let repository: D
+    
+    public init(_ dataSource: D) {
+        self.repository = dataSource
+    }
+    
+    public func put(_ value: T?, in query: Query, operation: Harmony.Operation) -> Future<T> {
+        putCalls.append((value, query, operation))
+        return repository.put(value, in: query, operation: operation)
+    }
+    
+    public func putAll(_ array: [T], in query: Query, operation: Harmony.Operation) -> Future<[T]> {
+        putAllCalls.append((array, query, operation))
+        return repository.putAll(array, in: query, operation: operation)
+    }
+}
+
+/// A DeleteRepository spy that records all calls.
+public class DeleteRepositorySpy <D: DeleteRepository>: DeleteRepository {
+    
+    public private(set) var deleteCalls: [(query: Query, operation: Harmony.Operation)] = []
+    public private(set) var deleteAllCalls: [(query: Query, operation: Harmony.Operation)] = []
+    
+    private let repository: D
+    
+    public init(_ dataSource: D) {
+        self.repository = dataSource
+    }
+    
+    public func delete(_ query: Query, operation: Harmony.Operation) -> Future<Void> {
+        deleteCalls.append((query, operation))
+        return repository.delete(query, operation: operation)
+    }
+    
+    public func deleteAll(_ query: Query, operation: Harmony.Operation) -> Future<Void> {
+        deleteAllCalls.append((query, operation))
+        return repository.deleteAll(query, operation: operation)
+    }
+}
+
+/// A Repository spy that records all calls.
+public class RepositorySpy <D,T> : GetRepository, PutRepository, DeleteRepository where D:GetRepository, D:PutRepository, D:DeleteRepository, D.T == T {
+    
+    public private(set) var getCalls: [(query: Query, operation: Harmony.Operation)] = []
+    public private(set) var getAllCalls: [(query: Query, operation: Harmony.Operation)] = []
+    
+    private let repository: D
+    
+    public init(_ dataSource: D) {
+        self.repository = dataSource
+    }
+    
+    public func get(_ query: Query, operation: Harmony.Operation) -> Future<T> {
+        getCalls.append((query, operation))
+        return repository.get(query, operation: operation)
+    }
+    
+    public func getAll(_ query: Query, operation: Harmony.Operation) -> Future<[T]> {
+        getAllCalls.append((query, operation))
+        return repository.getAll(query, operation: operation)
+    }
+    
+    public private(set) var putCalls: [(value: T?, query: Query, operation: Harmony.Operation)] = []
+    public private(set) var putAllCalls: [(array: [T], query: Query, operation: Harmony.Operation)] = []
+    
+    public func put(_ value: T?, in query: Query, operation: Harmony.Operation) -> Future<T> {
+        putCalls.append((value, query, operation))
+        return repository.put(value, in: query, operation: operation)
+    }
+    
+    public func putAll(_ array: [T], in query: Query, operation: Harmony.Operation) -> Future<[T]> {
+        putAllCalls.append((array, query, operation))
+        return repository.putAll(array, in: query, operation: operation)
+    }
+    
+    public private(set) var deleteCalls: [(query: Query, operation: Harmony.Operation)] = []
+    public private(set) var deleteAllCalls: [(query: Query, operation: Harmony.Operation)] = []
+    
+    public func delete(_ query: Query, operation: Harmony.Operation) -> Future<Void> {
+        deleteCalls.append((query, operation))
+        return repository.delete(query, operation: operation)
+    }
+    
+    public func deleteAll(_ query: Query, operation: Harmony.Operation) -> Future<Void> {
+        deleteAllCalls.append((query, operation))
+        return repository.deleteAll(query, operation: operation)
+    }
+}

--- a/Tests/HarmonyTests/CacheRepositoryTests.swift
+++ b/Tests/HarmonyTests/CacheRepositoryTests.swift
@@ -60,18 +60,16 @@ class CacheRepositoryTests: XCTestCase {
     
     func test_getValue_withMain_withEmptyMain() throws {
         // Given
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: nil, cacheData: nil)
         let operation = MainOperation()
         
-        // When
-        do {
-            _ = try cacheRepository.get(query, operation: operation).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        expect {
+            // When
+            try self.cacheRepository.get(query, operation: operation).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
         expect(self.cacheSpy.getCalls.count).to(equal(0))
         expect(self.mainSpy.getCalls.count).to(equal(1))
         expect(self.mainSpy.getCalls[0]).to(be(query))
@@ -80,7 +78,7 @@ class CacheRepositoryTests: XCTestCase {
     func test_getValue_withMain_withMainValue() throws {
         // Given
         let value = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: (query, value), cacheData: nil)
         let operation = MainOperation()
         
@@ -96,18 +94,16 @@ class CacheRepositoryTests: XCTestCase {
     
     func test_getValue_withCache_withEmptyCache() throws {
         // Given
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: nil, cacheData: nil)
         let operation = CacheOperation()
         
-        // When
-        do {
-            _ = try cacheRepository.get(query, operation: operation).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        expect {
+            // When
+            try self.cacheRepository.get(query, operation: operation).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
         expect(self.mainSpy.getCalls.count).to(equal(0))
         expect(self.cacheSpy.getCalls.count).to(equal(1))
         expect(self.cacheSpy.getCalls[0]).to(be(query))
@@ -116,7 +112,7 @@ class CacheRepositoryTests: XCTestCase {
     func test_getValue_withCache_withCacheValue() throws {
         // Given
         let value = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: nil, cacheData: (query, value))
         let operation = CacheOperation()
         
@@ -133,7 +129,7 @@ class CacheRepositoryTests: XCTestCase {
     func test_getValue_withCacheSync_withEmptyCache_withMainValue() throws {
         // Given
         let value = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: (query, value), cacheData: nil)
         let operation = CacheSyncOperation()
         
@@ -152,7 +148,7 @@ class CacheRepositoryTests: XCTestCase {
     func test_getValue_withCacheSync_withValidCacheValue() throws {
         // Given
         let value = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: nil, cacheData: (query, value))
         let operation = CacheSyncOperation()
         
@@ -170,7 +166,7 @@ class CacheRepositoryTests: XCTestCase {
         // Given
         let validValue = Int.random()
         let invalidValue = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: (query, validValue), cacheData: (query, invalidValue), objectValid: false)
         let operation = CacheSyncOperation()
         
@@ -191,18 +187,16 @@ class CacheRepositoryTests: XCTestCase {
     func test_getValue_withCacheSync_withInvalidCacheValue_withEmptyMain() throws {
         // Given
         let invalidValue = Int.random()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         try setup(mainData: nil, cacheData: (query, invalidValue), objectValid: false)
         let operation = CacheSyncOperation()
         
-        // When
-        do {
-            _ = try cacheRepository.get(query, operation: operation).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        expect {
+            // When
+            try self.cacheRepository.get(query, operation: operation).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
         expect(self.mainSpy.getCalls.count).to(equal(1))
         expect(self.mainSpy.getCalls[0]).to(be(query))
         expect(self.cacheSpy.getCalls.count).to(equal(1))

--- a/Tests/HarmonyTests/CacheRepositoryTests.swift
+++ b/Tests/HarmonyTests/CacheRepositoryTests.swift
@@ -1,0 +1,213 @@
+//
+// Copyright 2022 Mobile Jazz SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import Nimble
+import XCTest
+import Harmony
+import HarmonyTesting
+
+class CacheRepositoryTests: XCTestCase {
+    
+    private var main: InMemoryDataSource<Int>!
+    private var cache: InMemoryDataSource<Int>!
+    
+    private typealias DataSourceSpyType = DataSourceSpy<InMemoryDataSource<Int>, Int>
+    
+    private var mainSpy: DataSourceSpyType!
+    private var cacheSpy: DataSourceSpyType!
+    
+    private var cacheRepository: CacheRepository<DataSourceSpyType, DataSourceSpyType, Int>!
+
+    private func setup(
+        mainData mainKeyValue: (query: KeyQuery, value: Int)?,
+        cacheData cacheKeyValue: (query: KeyQuery, value: Int)?,
+        objectValid: Bool = true
+    ) throws {
+        main = InMemoryDataSource()
+        cache = InMemoryDataSource()
+        
+        mainSpy = DataSourceSpy(main)
+        cacheSpy = DataSourceSpy(cache)
+        
+        cacheRepository = CacheRepository(
+            main: mainSpy,
+            cache: cacheSpy,
+            validator: MockObjectValidation<Int>(objectValid: objectValid, arrayValid: true)
+        )
+        
+        if let mainKeyValue = mainKeyValue {
+            _ = try main.put(mainKeyValue.value, in: mainKeyValue.query).result.get()
+        }
+        
+        if let cacheKeyValue = cacheKeyValue {
+            _ = try cache.put(cacheKeyValue.value, in: cacheKeyValue.query).result.get()
+        }
+    }
+    
+    func test_getValue_withMain_withEmptyMain() throws {
+        // Given
+        let query = IdQuery("id")
+        try setup(mainData: nil, cacheData: nil)
+        let operation = MainOperation()
+        
+        // When
+        do {
+            _ = try cacheRepository.get(query, operation: operation).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        }
+        expect(self.cacheSpy.getCalls.count).to(equal(0))
+        expect(self.mainSpy.getCalls.count).to(equal(1))
+        expect(self.mainSpy.getCalls[0]).to(be(query))
+    }
+    
+    func test_getValue_withMain_withMainValue() throws {
+        // Given
+        let value = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: (query, value), cacheData: nil)
+        let operation = MainOperation()
+        
+        // When
+        let result = try cacheRepository.get(query, operation: operation).result.get()
+        
+        // Then
+        expect(result).to(equal(value))
+        expect(self.cacheSpy.getCalls.count).to(equal(0))
+        expect(self.mainSpy.getCalls.count).to(equal(1))
+        expect(self.mainSpy.getCalls[0]).to(be(query))
+    }
+    
+    func test_getValue_withCache_withEmptyCache() throws {
+        // Given
+        let query = IdQuery("id")
+        try setup(mainData: nil, cacheData: nil)
+        let operation = CacheOperation()
+        
+        // When
+        do {
+            _ = try cacheRepository.get(query, operation: operation).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        }
+        expect(self.mainSpy.getCalls.count).to(equal(0))
+        expect(self.cacheSpy.getCalls.count).to(equal(1))
+        expect(self.cacheSpy.getCalls[0]).to(be(query))
+    }
+    
+    func test_getValue_withCache_withCacheValue() throws {
+        // Given
+        let value = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: nil, cacheData: (query, value))
+        let operation = CacheOperation()
+        
+        // When
+        let result = try cacheRepository.get(query, operation: operation).result.get()
+        
+        // Then
+        expect(result).to(equal(value))
+        expect(self.mainSpy.getCalls.count).to(equal(0))
+        expect(self.cacheSpy.getCalls.count).to(equal(1))
+        expect(self.cacheSpy.getCalls[0]).to(be(query))
+    }
+    
+    func test_getValue_withCacheSync_withEmptyCache_withMainValue() throws {
+        // Given
+        let value = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: (query, value), cacheData: nil)
+        let operation = CacheSyncOperation()
+        
+        // When
+        let result = try cacheRepository.get(query, operation: operation).result.get()
+        
+        // Then
+        expect(result).to(equal(value))
+        expect(self.mainSpy.getCalls.count).to(equal(1))
+        expect(self.mainSpy.getCalls[0]).to(be(query))
+        expect(self.cacheSpy.putCalls.count).to(equal(1))
+        expect(self.cacheSpy.putCalls[0].value).to(equal(value))
+        expect(self.cacheSpy.putCalls[0].query).to(be(query))
+    }
+    
+    func test_getValue_withCacheSync_withValidCacheValue() throws {
+        // Given
+        let value = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: nil, cacheData: (query, value))
+        let operation = CacheSyncOperation()
+        
+        // When
+        let result = try cacheRepository.get(query, operation: operation).result.get()
+        
+        // Then
+        expect(result).to(equal(value))
+        expect(self.mainSpy.getCalls.count).to(equal(0))
+        expect(self.cacheSpy.getCalls.count).to(equal(1))
+        expect(self.cacheSpy.getCalls[0]).to(be(query))
+    }
+    
+    func test_getValue_withCacheSync_withInvalidCacheValue_withMainValue() throws {
+        // Given
+        let validValue = Int.random()
+        let invalidValue = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: (query, validValue), cacheData: (query, invalidValue), objectValid: false)
+        let operation = CacheSyncOperation()
+        
+        // When
+        let result = try cacheRepository.get(query, operation: operation).result.get()
+        
+        // Then
+        expect(result).to(equal(validValue))
+        expect(self.mainSpy.getCalls.count).to(equal(1))
+        expect(self.mainSpy.getCalls[0]).to(be(query))
+        expect(self.cacheSpy.getCalls.count).to(equal(1))
+        expect(self.cacheSpy.getCalls[0]).to(be(query))
+        expect(self.cacheSpy.putCalls.count).to(equal(1))
+        expect(self.cacheSpy.putCalls[0].value).to(equal(validValue))
+        expect(self.cacheSpy.putCalls[0].query).to(be(query))
+    }
+    
+    func test_getValue_withCacheSync_withInvalidCacheValue_withEmptyMain() throws {
+        // Given
+        let invalidValue = Int.random()
+        let query = IdQuery("id")
+        try setup(mainData: nil, cacheData: (query, invalidValue), objectValid: false)
+        let operation = CacheSyncOperation()
+        
+        // When
+        do {
+            _ = try cacheRepository.get(query, operation: operation).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        }
+        expect(self.mainSpy.getCalls.count).to(equal(1))
+        expect(self.mainSpy.getCalls[0]).to(be(query))
+        expect(self.cacheSpy.getCalls.count).to(equal(1))
+        expect(self.cacheSpy.getCalls[0]).to(be(query))
+    }
+}
+
+

--- a/Tests/HarmonyTests/InMemoryDataSourceTests.swift
+++ b/Tests/HarmonyTests/InMemoryDataSourceTests.swift
@@ -28,8 +28,8 @@ class InMemoryDataSourceTests: XCTestCase {
     func test_put_value() throws {
         // Given
         let dataSoruce = provideEmptyDataSource()
-        let query = IdQuery("id")
-        let value = 42
+        let query = IdQuery(String(randomOfLength: 8))
+        let value = Int.random()
         
         // When
         _ = try dataSoruce.put(value, in: query).result.get()
@@ -42,34 +42,32 @@ class InMemoryDataSourceTests: XCTestCase {
     func test_delete_value() throws {
         // Given
         let dataSoruce = provideEmptyDataSource()
-        let query = IdQuery("id")
-        let value = 42
+        let query = IdQuery(String(randomOfLength: 8))
+        let value = Int.random()
         _ = try dataSoruce.put(value, in: query).result.get()
         
         // When
         try dataSoruce.delete(query).result.get()
-        do {
-            // Then
-            _ = try dataSoruce.get(query).result.get()
-            XCTAssert(false)
-        } catch {
-            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        
+        // Then
+        expect {
+            try dataSoruce.get(query).result.get()
         }
+        .to(throwError(errorType: CoreError.NotFound.self))
+        
     }
     
     func test_get_value_not_found() throws {
         // Given
         let dataSoruce = provideEmptyDataSource()
-        let query = IdQuery("id")
+        let query = IdQuery(String(randomOfLength: 8))
         
-        // When
-        do {
-            _ = try dataSoruce.get(query).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        expect {
+            // When
+            try dataSoruce.get(query).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
     }
     
     func test_get_non_valid_query() throws {
@@ -77,14 +75,12 @@ class InMemoryDataSourceTests: XCTestCase {
         let dataSoruce = provideEmptyDataSource()
         let query = VoidQuery()
         
-        // When
-        do {
-            _ = try dataSoruce.get(query).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        expect {
+            // When
+            try dataSoruce.get(query).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.QueryNotSupported.self))
     }
     
     func test_put_non_valid_query() throws {
@@ -93,15 +89,12 @@ class InMemoryDataSourceTests: XCTestCase {
         let query = VoidQuery()
         let value = Int.random()
         
-        // When
-        do {
-            _ = try dataSoruce.put(value, in: query).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        expect {
+            // When
+            try dataSoruce.put(value, in: query).result.get()
         }
-        
+        // Then
+        .to(throwError(errorType: CoreError.QueryNotSupported.self))
     }
     
     func test_delete_non_valid_query() throws {
@@ -109,13 +102,11 @@ class InMemoryDataSourceTests: XCTestCase {
         let dataSoruce = provideEmptyDataSource()
         let query = VoidQuery()
         
-        // When
-        do {
-            _ = try dataSoruce.delete(query).result.get()
-            XCTAssert(false)
-        } catch {
-            // Then
-            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        expect {
+            // When
+            try dataSoruce.delete(query).result.get()
         }
+        // Then
+        .to(throwError(errorType: CoreError.QueryNotSupported.self))
     }
 }

--- a/Tests/HarmonyTests/InMemoryDataSourceTests.swift
+++ b/Tests/HarmonyTests/InMemoryDataSourceTests.swift
@@ -1,0 +1,121 @@
+//
+// Copyright 2022 Mobile Jazz SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import Nimble
+import XCTest
+import Harmony
+
+class InMemoryDataSourceTests: XCTestCase {
+    
+    private func provideEmptyDataSource() -> InMemoryDataSource<Int> {
+        return InMemoryDataSource<Int>()
+    }
+    
+    func test_put_value() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = IdQuery("id")
+        let value = 42
+        
+        // When
+        _ = try dataSoruce.put(value, in: query).result.get()
+        
+        // Then
+        let result = try dataSoruce.get(query).result.get()
+        expect(result).to(equal(value))
+    }
+    
+    func test_delete_value() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = IdQuery("id")
+        let value = 42
+        _ = try dataSoruce.put(value, in: query).result.get()
+        
+        // When
+        try dataSoruce.delete(query).result.get()
+        do {
+            // Then
+            _ = try dataSoruce.get(query).result.get()
+            XCTAssert(false)
+        } catch {
+            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        }
+    }
+    
+    func test_get_value_not_found() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = IdQuery("id")
+        
+        // When
+        do {
+            _ = try dataSoruce.get(query).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.NotFound.self))
+        }
+    }
+    
+    func test_get_non_valid_query() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = VoidQuery()
+        
+        // When
+        do {
+            _ = try dataSoruce.get(query).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        }
+    }
+    
+    func test_put_non_valid_query() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = VoidQuery()
+        let value = Int.random()
+        
+        // When
+        do {
+            _ = try dataSoruce.put(value, in: query).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        }
+        
+    }
+    
+    func test_delete_non_valid_query() throws {
+        // Given
+        let dataSoruce = provideEmptyDataSource()
+        let query = VoidQuery()
+        
+        // When
+        do {
+            _ = try dataSoruce.delete(query).result.get()
+            XCTAssert(false)
+        } catch {
+            // Then
+            expect(error).to(beAnInstanceOf(CoreError.QueryNotSupported.self))
+        }
+    }
+}


### PR DESCRIPTION
**Merge / Pull request information**

* Asana task link: https://app.asana.com/0/1109863238977521/1202462981511859/f

Included in the PR:
- Adding number random generator in Harmony.
- Adding DataSoruce and Repository Spy classes in HarmonyTesting.
- Adding Mock ObjectValidation class in HarmonyTesting.
- Adding unit tests for cache and in-memory data source.
- Created new QueryNotSupported error
- Edited InMemoryDataSource to return QueryNotSupported error instead of fatal error

The goal of PR is to gather all the outcomes from the RW testing session and include them in the repo. If you guys have more tests to add or want to replace mine for others, you're welcome to do it (I'm not an expert in testing).