### PR TITLE
iOS-5017 :: Feature :: Deprecate deleteAll

### DIFF
--- a/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		24C7BD6B28C793980046F15C /* FileSystemStorageDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6928C753030046F15C /* FileSystemStorageDataSourceTests.swift */; };
+		24C7BD6D28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6C28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift */; };
+		24C7BD6F28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6E28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift */; };
+		24C7BD7128CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD7028CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift */; };
+		24C7BD7328CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD7228CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift */; };
+		24C7BD7528CA11B30046F15C /* TimedCacheDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD7428CA11B30046F15C /* TimedCacheDataSourceTests.swift */; };
 		5932E95727A9472D00253261 /* UUIDObjectMother.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5192327A9463D00A18D72 /* UUIDObjectMother.swift */; };
 		5932E95827A9472D00253261 /* BoolObjectMother.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5191D27A9460A00A18D72 /* BoolObjectMother.swift */; };
 		5932E95927A9472D00253261 /* DoubleObjectMother.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5191C27A9460A00A18D72 /* DoubleObjectMother.swift */; };
@@ -225,6 +231,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		24C7BD6928C753030046F15C /* FileSystemStorageDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemStorageDataSourceTests.swift; sourceTree = "<group>"; };
+		24C7BD6C28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourceTester.swift; sourceTree = "<group>"; };
+		24C7BD6E28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourceRegularTests.swift; sourceTree = "<group>"; };
+		24C7BD7028CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourcePrefixTests.swift; sourceTree = "<group>"; };
+		24C7BD7228CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourceRootKeyTests.swift; sourceTree = "<group>"; };
+		24C7BD7428CA11B30046F15C /* TimedCacheDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimedCacheDataSourceTests.swift; sourceTree = "<group>"; };
 		59881E7A27A9D6D700D92121 /* HarmonyTesting.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = HarmonyTesting.podspec; sourceTree = "<group>"; };
 		59881E7B27A9DC9500D92121 /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		59A418C5284E240300E33F2D /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
@@ -783,6 +795,12 @@
 				D28C13F2285B090500E4F2CA /* FutureTests.swift */,
 				D2067A3F285C618600A1047E /* CacheRepositoryTests.swift */,
 				D2067A49285C64AD00A1047E /* InMemoryDataSourceTests.swift */,
+				24C7BD6928C753030046F15C /* FileSystemStorageDataSourceTests.swift */,
+				24C7BD6C28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift */,
+				24C7BD6E28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift */,
+				24C7BD7028CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift */,
+				24C7BD7228CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift */,
+				24C7BD7428CA11B30046F15C /* TimedCacheDataSourceTests.swift */,
 			);
 			path = HarmonyTests;
 			sourceTree = "<group>";
@@ -1793,8 +1811,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2067A40285C618600A1047E /* CacheRepositoryTests.swift in Sources */,
+				24C7BD6B28C793980046F15C /* FileSystemStorageDataSourceTests.swift in Sources */,
 				D28C13F3285B090500E4F2CA /* FutureTests.swift in Sources */,
 				D2067A4A285C64AD00A1047E /* InMemoryDataSourceTests.swift in Sources */,
+				24C7BD7528CA11B30046F15C /* TimedCacheDataSourceTests.swift in Sources */,
+				24C7BD7328CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift in Sources */,
+				24C7BD6D28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift in Sources */,
+				24C7BD6F28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift in Sources */,
+				24C7BD7128CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Harmony/Data/DataSource/DataSource.swift
+++ b/Sources/Harmony/Data/DataSource/DataSource.swift
@@ -97,6 +97,7 @@ public protocol DeleteDataSource : DataSource {
     ///
     /// - Parameter query: An instance conforming to Query that encapusles the delete query information
     /// - Returns: A future of Void type.
+    @available(*, deprecated, message: "Use delete with AllObjectsQuery to remove all entries or with any other Query to remove one or more entries")
     @discardableResult
     func deleteAll(_ query: Query) -> Future<Void>
 }
@@ -107,6 +108,7 @@ extension DeleteDataSource {
         return delete(IdQuery(id))
     }
     
+    @available(*, deprecated, message: "Use delete instead")
     @discardableResult
     public func deleteAll<K>(_ id: K) -> Future<Void> where K:Hashable {
         return deleteAll(IdQuery(id))

--- a/Sources/Harmony/Data/DataSource/TimedCacheDataSource.swift
+++ b/Sources/Harmony/Data/DataSource/TimedCacheDataSource.swift
@@ -87,6 +87,7 @@ public class TimedCacheDataSource<T,D> : GetDataSource, PutDataSource, DeleteDat
         switch query {
         case let query as KeyQuery:
             return dataSource.put(value, in: query).then { object in
+                self.arrays[query.key] =  nil
                 self.objects[query.key] = (object, Date())
                 }.fail { error in
                     self.objects[query.key] = nil
@@ -102,6 +103,7 @@ public class TimedCacheDataSource<T,D> : GetDataSource, PutDataSource, DeleteDat
         switch query {
         case let query as KeyQuery:
             return dataSource.putAll(array, in: query).then { array in
+                self.objects[query.key] = nil
                 self.arrays[query.key] = (array, Date())
                 }.fail { error in
                     self.arrays[query.key] = nil
@@ -118,6 +120,7 @@ public class TimedCacheDataSource<T,D> : GetDataSource, PutDataSource, DeleteDat
         case let query as KeyQuery:
             return dataSource.delete(query).onCompletion {
                 self.objects[query.key] = nil
+                self.arrays[query.key] = nil
             }
         default:
             print("TimedCacheDataSource can't cache the result of the \(type(of: dataSource)).delete call because \(type(of: query)) doesn't conform to KeyQuery.")
@@ -127,15 +130,7 @@ public class TimedCacheDataSource<T,D> : GetDataSource, PutDataSource, DeleteDat
     
     @discardableResult
     public func deleteAll(_ query: Query) -> Future<Void> {
-        switch query {
-        case let query as KeyQuery:
-            return dataSource.delete(query).onCompletion {
-                self.arrays[query.key] = nil
-            }
-        default:
-            print("TimedCacheDataSource can't cache the result of the \(type(of: dataSource)).deleteAll call because \(type(of: query)) doesn't conform to KeyQuery.")
-            return dataSource.deleteAll(query)
-        }
+        delete(query)
     }
 }
 

--- a/Sources/Harmony/Data/Repository/Repository.swift
+++ b/Sources/Harmony/Data/Repository/Repository.swift
@@ -89,6 +89,7 @@ public protocol DeleteRepository : Repository {
     ///
     /// - Parameter query: An instance conforming to Query that encapusles the delete query information
     /// - Returns: A future of Void type.
+    @available(*, deprecated, message: "Use delete with AllObjectsQuery to remove all entries or with any other Query to remove one or more entries")
     @discardableResult
     func deleteAll(_ query: Query, operation: Operation) -> Future<Void>
 }
@@ -99,6 +100,7 @@ extension DeleteRepository {
         return delete(IdQuery(id), operation: operation)
     }
     
+    @available(*, deprecated, message: "Use delete instead")
     @discardableResult
     public func deleteAll<K>(_ id: K, operation: Operation) -> Future<Void> where K:Hashable {
         return deleteAll(IdQuery(id), operation: operation)

--- a/Sources/HarmonyTesting/Data/DataSourceSpy.swift
+++ b/Sources/HarmonyTesting/Data/DataSourceSpy.swift
@@ -23,20 +23,20 @@ public class GetDataSourceSpy <D: GetDataSource, T> : GetDataSource where D.T ==
     public private(set) var getCalls: [Query] = []
     public private(set) var getAllCalls: [Query] = []
     
-    private let dataSoruce: D
+    private let dataSource: D
     
     public init(_ dataSource: D) {
-        self.dataSoruce = dataSource
+        self.dataSource = dataSource
     }
     
     public func get(_ query: Query) -> Future<T> {
         getCalls.append(query)
-        return dataSoruce.get(query)
+        return dataSource.get(query)
     }
     
     public func getAll(_ query: Query) -> Future<[T]> {
         getAllCalls.append(query)
-        return dataSoruce.getAll(query)
+        return dataSource.getAll(query)
     }
 }
 
@@ -46,20 +46,20 @@ public class PutDataSourceSpy <D: PutDataSource, T> : PutDataSource where D.T ==
     public private(set) var putCalls: [(value: T?, query: Query)] = []
     public private(set) var putAllCalls: [(array: [T], query: Query)] = []
     
-    private let dataSoruce: D
+    private let dataSource: D
     
     public init(_ dataSource: D) {
-        self.dataSoruce = dataSource
+        self.dataSource = dataSource
     }
     
     public func put(_ value: T?, in query: Query) -> Future<T> {
         putCalls.append((value, query))
-        return dataSoruce.put(value, in: query)
+        return dataSource.put(value, in: query)
     }
     
     public func putAll(_ array: [T], in query: Query) -> Future<[T]> {
         putAllCalls.append((array, query))
-        return dataSoruce.putAll(array, in: query)
+        return dataSource.putAll(array, in: query)
     }
 }
 
@@ -69,20 +69,20 @@ public class DeleteDataSourceSpy <D: DeleteDataSource>: DeleteDataSource {
     public private(set) var deleteCalls: [Query] = []
     public private(set) var deleteAllCalls: [Query] = []
     
-    private let dataSoruce: D
+    private let dataSource: D
     
     public init(_ dataSource: D) {
-        self.dataSoruce = dataSource
+        self.dataSource = dataSource
     }
     
     public func delete(_ query: Query) -> Future<Void> {
         deleteCalls.append(query)
-        return dataSoruce.delete(query)
+        return dataSource.delete(query)
     }
     
     public func deleteAll(_ query: Query) -> Future<Void> {
         deleteAllCalls.append(query)
-        return dataSoruce.deleteAll(query)
+        return dataSource.deleteAll(query)
     }
 }
 
@@ -92,20 +92,20 @@ public class DataSourceSpy <D,T> : GetDataSource, PutDataSource, DeleteDataSourc
     public private(set) var getCalls: [Query] = []
     public private(set) var getAllCalls: [Query] = []
     
-    private let dataSoruce: D
+    private let dataSource: D
     
     public init(_ dataSource: D) {
-        self.dataSoruce = dataSource
+        self.dataSource = dataSource
     }
     
     public func get(_ query: Query) -> Future<T> {
         getCalls.append(query)
-        return dataSoruce.get(query)
+        return dataSource.get(query)
     }
     
     public func getAll(_ query: Query) -> Future<[T]> {
         getAllCalls.append(query)
-        return dataSoruce.getAll(query)
+        return dataSource.getAll(query)
     }
     
     public private(set) var putCalls: [(value: T?, query: Query)] = []
@@ -113,12 +113,12 @@ public class DataSourceSpy <D,T> : GetDataSource, PutDataSource, DeleteDataSourc
     
     public func put(_ value: T?, in query: Query) -> Future<T> {
         putCalls.append((value, query))
-        return dataSoruce.put(value, in: query)
+        return dataSource.put(value, in: query)
     }
     
     public func putAll(_ array: [T], in query: Query) -> Future<[T]> {
         putAllCalls.append((array, query))
-        return dataSoruce.putAll(array, in: query)
+        return dataSource.putAll(array, in: query)
     }
     
     public private(set) var deleteCalls: [Query] = []
@@ -126,11 +126,11 @@ public class DataSourceSpy <D,T> : GetDataSource, PutDataSource, DeleteDataSourc
     
     public func delete(_ query: Query) -> Future<Void> {
         deleteCalls.append(query)
-        return dataSoruce.delete(query)
+        return dataSource.delete(query)
     }
     
     public func deleteAll(_ query: Query) -> Future<Void> {
         deleteAllCalls.append(query)
-        return dataSoruce.deleteAll(query)
+        return dataSource.deleteAll(query)
     }
 }

--- a/Tests/HarmonyTests/DeviceStorageDataSourcePrefixTests.swift
+++ b/Tests/HarmonyTests/DeviceStorageDataSourcePrefixTests.swift
@@ -1,0 +1,87 @@
+//
+//  DeviceStorageDataSourcePrefixTests.swift
+//  HarmonyTests
+//
+//  Created by Fran Montiel on 8/9/22.
+//
+
+import Foundation
+import XCTest
+
+class DeviceStorageDataSourcePrefixTests: XCTestCase {
+    
+    private let tester = DeviceStorageDataSourceTester(DeviceStorageDataSourceObjectMother(deviceStorageType: .prefix("test-prefix")))
+    
+    override func tearDown() {
+        tester.tearDown()
+    }
+    
+    func test_get_value() throws {
+        try tester.test_get_value()
+    }
+    
+    func test_getAll_value() throws {
+        try tester.test_getAll_value()
+    }
+    
+    func test_put_value() throws {
+        try tester.test_put_value()
+    }
+    
+    func test_put_dictionary_value() throws {
+        try tester.test_put_dictionary_value()
+    }
+    
+    func test_put_array_value() throws {
+        try tester.test_put_array_value()
+    }
+    
+    func test_putAll_array_value_with_idQuery() throws {
+        try tester.test_putAll_array_value_with_idQuery()
+    }
+    
+    func test_putAll_array_value_with_idsQuery() throws {
+        try tester.test_putAll_array_value_with_idsQuery()
+    }
+    
+    func test_delete_value() throws {
+        try tester.test_delete_value()
+    }
+    
+    func test_delete_all_values() throws {
+        try tester.test_delete_all_values()
+    }
+    
+    func test_get_value_not_found() throws {
+        try tester.test_get_value_not_found()
+    }
+    
+    func test_getAll_value_not_found() throws {
+        try tester.test_getAll_value_not_found()
+    }
+    
+    func test_get_non_valid_query() throws {
+        try tester.test_get_non_valid_query()
+    }
+    
+    func test_getAll_non_valid_query() throws {
+        try tester.test_getAll_non_valid_query()
+    }
+    
+    func test_put_non_valid_query() throws {
+        try tester.test_put_non_valid_query()
+    }
+    
+    func test_putAll_non_valid_query() throws {
+        try tester.test_putAll_non_valid_query()
+    }
+    
+    func test_delete_non_valid_query() throws {
+        try tester.test_delete_non_valid_query()
+    }
+    
+    func test_should_replace_previous_value_when_inserting_with_existing_key() throws {
+        try tester.test_should_replace_previous_value_when_inserting_with_existing_key()
+    }
+
+}

--- a/Tests/HarmonyTests/DeviceStorageDataSourceRegularTests.swift
+++ b/Tests/HarmonyTests/DeviceStorageDataSourceRegularTests.swift
@@ -1,0 +1,89 @@
+//
+//  DeviceStorageDataSourceRegularTests.swift
+//  HarmonyTests
+//
+//  Created by Fran Montiel on 8/9/22.
+//
+
+import Foundation
+import XCTest
+
+class DeviceStorageDataSourceRegularTests: XCTestCase {
+    
+    private let tester = DeviceStorageDataSourceTester(DeviceStorageDataSourceObjectMother(deviceStorageType: .regular))
+    
+    override func tearDown() {
+        tester.tearDown()
+    }
+    
+    func test_get_value() throws {
+        try tester.test_get_value()
+    }
+    
+    func test_getAll_value() throws {
+        try tester.test_getAll_value()
+    }
+    
+    func test_put_value() throws {
+        try tester.test_put_value()
+    }
+    
+    func test_put_dictionary_value() throws {
+        try tester.test_put_dictionary_value()
+    }
+    
+    func test_put_array_value() throws {
+        try tester.test_put_array_value()
+    }
+    
+    func test_putAll_array_value_with_idQuery() throws {
+        try tester.test_putAll_array_value_with_idQuery()
+    }
+    
+    func test_putAll_array_value_with_idsQuery() throws {
+        try tester.test_putAll_array_value_with_idsQuery()
+    }
+    
+    func test_delete_value() throws {
+        try tester.test_delete_value()
+    }
+    
+    func test_delete_all_values() throws {
+        // TODO: decide what to do with deleteAll implementation when deviceStorageType is regular
+//        try tester.test_delete_all_values()
+        
+    }
+    
+    func test_get_value_not_found() throws {
+        try tester.test_get_value_not_found()
+    }
+    
+    func test_getAll_value_not_found() throws {
+        try tester.test_getAll_value_not_found()
+    }
+    
+    func test_get_non_valid_query() throws {
+        try tester.test_get_non_valid_query()
+    }
+    
+    func test_getAll_non_valid_query() throws {
+        try tester.test_getAll_non_valid_query()
+    }
+    
+    func test_put_non_valid_query() throws {
+        try tester.test_put_non_valid_query()
+    }
+    
+    func test_putAll_non_valid_query() throws {
+        try tester.test_putAll_non_valid_query()
+    }
+    
+    func test_delete_non_valid_query() throws {
+        try tester.test_delete_non_valid_query()
+    }
+    
+    func test_should_replace_previous_value_when_inserting_with_existing_key() throws {
+        try tester.test_should_replace_previous_value_when_inserting_with_existing_key()
+    }
+    
+}

--- a/Tests/HarmonyTests/DeviceStorageDataSourceRootKeyTests.swift
+++ b/Tests/HarmonyTests/DeviceStorageDataSourceRootKeyTests.swift
@@ -1,0 +1,87 @@
+//
+//  DeviceStorageDataSourceRootKeyTests.swift
+//  HarmonyTests
+//
+//  Created by Fran Montiel on 8/9/22.
+//
+
+import Foundation
+import XCTest
+
+class DeviceStorageDataSourceRootKeyTests: XCTestCase {
+    
+    private let tester = DeviceStorageDataSourceTester(DeviceStorageDataSourceObjectMother(deviceStorageType: .rootKey("test-root-key")))
+    
+    override func tearDown() {
+        tester.tearDown()
+    }
+    
+    func test_get_value() throws {
+        try tester.test_get_value()
+    }
+    
+    func test_getAll_value() throws {
+        try tester.test_getAll_value()
+    }
+    
+    func test_put_value() throws {
+        try tester.test_put_value()
+    }
+    
+    func test_put_dictionary_value() throws {
+        try tester.test_put_dictionary_value()
+    }
+    
+    func test_put_array_value() throws {
+        try tester.test_put_array_value()
+    }
+    
+    func test_putAll_array_value_with_idQuery() throws {
+        try tester.test_putAll_array_value_with_idQuery()
+    }
+    
+    func test_putAll_array_value_with_idsQuery() throws {
+        try tester.test_putAll_array_value_with_idsQuery()
+    }
+    
+    func test_delete_value() throws {
+        try tester.test_delete_value()
+    }
+    
+    func test_delete_all_values() throws {
+        try tester.test_delete_all_values()
+    }
+    
+    func test_get_value_not_found() throws {
+        try tester.test_get_value_not_found()
+    }
+    
+    func test_getAll_value_not_found() throws {
+        try tester.test_getAll_value_not_found()
+    }
+    
+    func test_get_non_valid_query() throws {
+        try tester.test_get_non_valid_query()
+    }
+    
+    func test_getAll_non_valid_query() throws {
+        try tester.test_getAll_non_valid_query()
+    }
+    
+    func test_put_non_valid_query() throws {
+        try tester.test_put_non_valid_query()
+    }
+    
+    func test_putAll_non_valid_query() throws {
+        try tester.test_putAll_non_valid_query()
+    }
+    
+    func test_delete_non_valid_query() throws {
+        try tester.test_delete_non_valid_query()
+    }
+    
+    func test_should_replace_previous_value_when_inserting_with_existing_key() throws {
+        try tester.test_should_replace_previous_value_when_inserting_with_existing_key()
+    }
+
+}

--- a/Tests/HarmonyTests/DeviceStorageDataSourceTester.swift
+++ b/Tests/HarmonyTests/DeviceStorageDataSourceTester.swift
@@ -1,0 +1,310 @@
+//
+//  DeviceStorageDataSource.swift
+//  HarmonyTests
+//
+//  Created by Fran Montiel on 7/9/22.
+//
+
+import Foundation
+import Nimble
+import XCTest
+import Harmony
+
+struct DeviceStorageDataSourceObjectMother {
+    let deviceStorageType: DeviceStorageType
+
+    func provideDataSource<T>(userDefaults: UserDefaults, insertValue: (IdQuery<String>, T)? = nil, insertValues: (IdQuery<String>, [T])? = nil) throws -> DeviceStorageDataSource<T> {
+        let dataSource = DeviceStorageDataSource<T>(userDefaults, storageType: deviceStorageType)
+        
+        if let insertValue = insertValue {
+            try dataSource.put(insertValue.1, in: insertValue.0).result.get()
+        }
+        
+        if let insertValues = insertValues {
+            try dataSource.putAll(insertValues.1,in: insertValues.0).result.get()
+        }
+        
+        return dataSource
+    }
+}
+
+
+class DeviceStorageDataSourceTester {
+    
+    let dataSourceObjectMother: DeviceStorageDataSourceObjectMother
+    
+    init(_ dataSourceObjectMother: DeviceStorageDataSourceObjectMother) {
+        self.dataSourceObjectMother = dataSourceObjectMother
+    }
+    
+    let userDefaults = UserDefaults.standard
+    
+    private func provideDataSource<T>(insertValue: (IdQuery<String>, T)? = nil, insertValues: (IdQuery<String>, [T])? = nil) throws -> DeviceStorageDataSource<T> {
+        return try dataSourceObjectMother.provideDataSource(userDefaults: userDefaults, insertValue: insertValue, insertValues: insertValues)
+    }
+    
+    func tearDown() {
+        let dictionary = userDefaults.dictionaryRepresentation()
+        dictionary.keys.forEach { key in
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+    
+    func test_get_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = Int.random()
+        let dataSource = try provideDataSource(insertValue: (query, expectedValue))
+
+        // When
+        let actualValue = try dataSource.get(query).result.get()
+
+        // Then
+        expect(actualValue).to(equal(expectedValue))
+    }
+    
+    func test_getAll_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = [Int.random(), Int.random()]
+        let dataSource = try provideDataSource(insertValues: (query, expectedValue))
+
+        // When
+        let actualValue = try dataSource.getAll(query).result.get()
+
+        // Then
+        expect(actualValue).to(equal(expectedValue))
+    }
+    
+    func test_put_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = Int.random()
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+
+        // When
+        try dataSource.put(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.get(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_put_dictionary_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = [String(randomOfLength: 8): Int.random(), String(randomOfLength: 8): Int.random()]
+        let dataSource: DeviceStorageDataSource<[String: Int]> = try provideDataSource()
+
+        // When
+        try dataSource.put(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.get(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_put_array_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = [Int.random(), Int.random()]
+        let dataSource: DeviceStorageDataSource<[Int]> = try provideDataSource()
+
+        // When
+        try dataSource.put(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.get(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_putAll_array_value_with_idQuery() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = [Int.random(), Int.random()]
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+
+        // When
+        try dataSource.putAll(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.getAll(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_putAll_array_value_with_idsQuery() throws {
+        // Given
+        let query = IdsQuery([String(randomOfLength: 8), String(randomOfLength: 8)])
+        let expectedValue = [Int.random(), Int.random()]
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+
+        // When
+        try dataSource.putAll(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.getAll(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_delete_value() throws {
+        // Given
+        let value = Int.random()
+        let query = IdQuery(String(randomOfLength: 8))
+        let dataSource = try provideDataSource(insertValue: (query, value))
+        
+        // When
+        try dataSource.delete(query).result.get()
+        
+        // Then
+        expect {
+            try dataSource.get(query).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_delete_all_values() throws {
+        // Given
+        let value = Int.random()
+        let valueQuery = IdQuery(String(randomOfLength: 8))
+        let values = [Int.random(), Int.random()]
+        let valuesQuery = IdQuery(String(randomOfLength: 8))
+        let dataSource = try provideDataSource(insertValue: (valueQuery, value), insertValues: (valuesQuery, values))
+        
+        // When
+        try dataSource.delete(AllObjectsQuery()).result.get()
+        
+        // Then
+        expect {
+            try dataSource.get(valueQuery).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+        
+        // Then
+        expect {
+            try dataSource.get(valuesQuery).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_get_value_not_found() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = IdQuery(String(randomOfLength: 8))
+        
+        expect {
+            // When
+            try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_getAll_value_not_found() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = IdQuery(String(randomOfLength: 8))
+        
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_get_non_valid_query() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = VoidQuery()
+        
+        expect {
+            // When
+            try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_getAll_non_valid_query() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = VoidQuery()
+        
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_put_non_valid_query() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = VoidQuery()
+        let value = Int.random()
+        
+        expect {
+            // When
+            try dataSource.put(value, in: query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_putAll_non_valid_query() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = VoidQuery()
+        let value = [Int.random(), Int.random()]
+        
+        expect {
+            // When
+            try dataSource.putAll(value, in: query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_delete_non_valid_query() throws {
+        // Given
+        let dataSource: DeviceStorageDataSource<Int> = try provideDataSource()
+        let query = VoidQuery()
+
+        expect {
+            // When
+            try dataSource.delete(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_should_replace_previous_value_when_inserting_with_existing_key() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let firstValue = [Int.random(), Int.random()]
+        let secondValue = Int.random()
+        let dataSource = try provideDataSource(insertValues: (query, firstValue))
+        
+        expect {
+            // When
+            _ = dataSource.put(secondValue,in: query) // Put a new value using the same key
+            return try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(equal(secondValue)) // The new value is obtained
+
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self)) // The old value (list) is not there anymore
+    }
+    
+}

--- a/Tests/HarmonyTests/FileSystemStorageDataSourceTests.swift
+++ b/Tests/HarmonyTests/FileSystemStorageDataSourceTests.swift
@@ -1,0 +1,249 @@
+//
+//  FileSystemStorageDataSource.swift
+//  HarmonyTests
+//
+//  Created by Fran Montiel on 6/9/22.
+//
+
+import Foundation
+import Nimble
+import XCTest
+import Harmony
+
+class FileSystemStorageDataSourceTests: XCTestCase {
+    private func provideDataSource(insertValue: (IdQuery<String>, Data)? = nil, insertValues: (IdQuery<String>, [Data])? = nil) throws -> FileSystemStorageDataSource {
+        let dataSource = FileSystemStorageDataSource(fileManager: FileManager.default, relativePath: "test")!
+        
+        if let insertValue = insertValue {
+            try dataSource.put(insertValue.1, in: insertValue.0).result.get()
+        }
+        
+        if let insertValues = insertValues {
+            try dataSource.putAll(insertValues.1,in: insertValues.0).result.get()
+        }
+        
+        return dataSource
+    }
+    
+    override func tearDown() {
+        do {
+            try provideDataSource().delete(AllObjectsQuery()).result.get()
+        } catch {
+            // The directory was not created by a particular test (e.g: no inserted value)
+        }
+    }
+    
+    func test_get_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = String(randomOfLength: 8).data(using: .utf8)!
+        let dataSource = try provideDataSource(insertValue: (query, expectedValue))
+
+        // When
+        let actualValue = try dataSource.get(query).result.get()
+
+        // Then
+        expect(actualValue).to(equal(expectedValue))
+    }
+    
+    func test_getAll_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = [String(randomOfLength: 8).data(using: .utf8)!, String(randomOfLength: 8).data(using: .utf8)!]
+        let dataSource = try provideDataSource(insertValues: (query, expectedValue))
+
+        // When
+        let actualValue = try dataSource.getAll(query).result.get()
+
+        // Then
+        expect(actualValue).to(equal(expectedValue))
+    }
+    
+    func test_put_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue = String(randomOfLength: 8).data(using: .utf8)!
+        let dataSource = try provideDataSource()
+
+        // When
+        try dataSource.put(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.get(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_putAll_value() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let expectedValue =  [String(randomOfLength: 8).data(using: .utf8)!, String(randomOfLength: 8).data(using: .utf8)!]
+        let dataSource = try provideDataSource()
+
+        // When
+        try dataSource.putAll(expectedValue, in:query).result.get()
+
+        // Then
+        expect{
+           try dataSource.getAll(query).result.get()
+        }.to(equal(expectedValue))
+    }
+    
+    func test_delete_value() throws {
+        // Given
+        let value = String(randomOfLength: 8).data(using: .utf8)!
+        let valueQuery = IdQuery(String(randomOfLength: 8))
+        let dataSource = try provideDataSource(insertValue: (valueQuery, value))
+        
+        // When
+        try dataSource.delete(valueQuery).result.get()
+        
+        // Then
+        expect {
+            try dataSource.get(valueQuery).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_delete_all_values() throws {
+        // Given
+        let value = String(randomOfLength: 8).data(using: .utf8)!
+        let valueQuery = IdQuery(String(randomOfLength: 8))
+        let values = [String(randomOfLength: 8).data(using: .utf8)!, String(randomOfLength: 8).data(using: .utf8)!]
+        let valuesQuery = IdQuery(String(randomOfLength: 8))
+        let dataSource = try provideDataSource(insertValue: (valueQuery, value), insertValues: (valuesQuery, values))
+        
+        // When
+        try dataSource.delete(AllObjectsQuery()).result.get()
+        
+        // Then
+        expect {
+            try dataSource.get(valueQuery).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+        
+        // Then
+        expect {
+            try dataSource.get(valuesQuery).result.get()
+        }
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_get_value_not_found() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = IdQuery(String(randomOfLength: 8))
+        
+        expect {
+            // When
+            try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_getAll_value_not_found() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = IdQuery(String(randomOfLength: 8))
+        
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self))
+    }
+    
+    func test_get_non_valid_query() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = VoidQuery()
+        
+        expect {
+            // When
+            try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_getAll_non_valid_query() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = VoidQuery()
+        
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_put_non_valid_query() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = VoidQuery()
+        let value = String(randomOfLength: 8).data(using: .utf8)!
+        
+        expect {
+            // When
+            try dataSource.put(value, in: query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_putAll_non_valid_query() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = VoidQuery()
+        let value = [String(randomOfLength: 8).data(using: .utf8)!, String(randomOfLength: 8).data(using: .utf8)!]
+        
+        expect {
+            // When
+            try dataSource.putAll(value, in: query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_delete_non_valid_query() throws {
+        // Given
+        let dataSource = try provideDataSource()
+        let query = VoidQuery()
+
+        expect {
+            // When
+            try dataSource.delete(query).result.get()
+        }
+        // Then
+        .to(throwAssertion())
+    }
+    
+    func test_should_replace_previous_value_when_inserting_with_existing_key() throws {
+        // Given
+        let query = IdQuery(String(randomOfLength: 8))
+        let firstValue = [String(randomOfLength: 8).data(using: .utf8)!, String(randomOfLength: 8).data(using: .utf8)!]
+        let secondValue = String(randomOfLength: 8).data(using: .utf8)!
+        let dataSource = try provideDataSource(insertValues: (query, firstValue))
+        
+        expect {
+            // When
+            _ = dataSource.put(secondValue,in: query) // Put a new value using the same key
+            return try dataSource.get(query).result.get()
+        }
+        // Then
+        .to(equal(secondValue)) // The new value is obtained
+
+        expect {
+            // When
+            try dataSource.getAll(query).result.get()
+        }
+        // Then
+        .to(throwError(errorType: CoreError.NotFound.self)) // The old value (list) is not there anymore
+    }
+
+
+}

--- a/Tests/HarmonyTests/TimedCacheDataSourceTests.swift
+++ b/Tests/HarmonyTests/TimedCacheDataSourceTests.swift
@@ -1,28 +1,21 @@
 //
-// Copyright 2022 Mobile Jazz SL
+//  TimedCacheDataSourceTests.swift
+//  HarmonyTests
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Created by Fran Montiel on 8/9/22.
 //
 
+import Foundation
 import Foundation
 import Nimble
 import XCTest
 import Harmony
 
-class InMemoryDataSourceTests: XCTestCase {
+// TODO: Improve TimedCacheDataSourceTests to take into account expiration date. Use a spy to check wether the value is obtained from cache or not.
+class TimedCacheDataSourceTests: XCTestCase {
     
-    private func provideEmptyDataSource() -> InMemoryDataSource<Int> {
-        return InMemoryDataSource<Int>()
+    private func provideEmptyDataSource() -> TimedCacheDataSource<Int, InMemoryDataSource<Int>> {
+        return TimedCacheDataSource(InMemoryDataSource<Int>())
     }
     
     func test_put_value() throws {


### PR DESCRIPTION
This PR includes:
- Deprecation of `deleteAll` in Repositories and Data Sources (#15) 
- Fix duplicated keys on `InMemoryDataSource` and `TimedCacheDataSource` (#16)
  - Now if a new value with the same key is stored the previous one is always replaced (not matter if one is an array and the other is an object).
 - Add tests for all DataSources being changed in this PR
 - Fix two issues on DeviceStorageDataSource:
   -  `get` was returning default values for some types instead of `CoreError.NotFound` when defining `storageType` to be `regular`
   - `delete` with `AllObjectsQuery` was not working when defining `storageType` to be `rootKey`
 
**Merge / Pull request information:**

* Asana task link: https://app.asana.com/0/1109863238977521/1202713346925014
