### PR TITLE
IOS-4369 :: Feature :: Move ThreadDispatcher class from Clip Health to harmony swift

### DIFF
--- a/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		003485D528E4592A0045CC27 /* DelayedMainQueueExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003485D428E4592A0045CC27 /* DelayedMainQueueExecutorTests.swift */; };
 		24C7BD6B28C793980046F15C /* FileSystemStorageDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6928C753030046F15C /* FileSystemStorageDataSourceTests.swift */; };
 		24C7BD6D28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6C28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift */; };
 		24C7BD6F28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7BD6E28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift */; };
@@ -231,6 +232,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		003485D428E4592A0045CC27 /* DelayedMainQueueExecutorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelayedMainQueueExecutorTests.swift; sourceTree = "<group>"; };
 		24C7BD6928C753030046F15C /* FileSystemStorageDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemStorageDataSourceTests.swift; sourceTree = "<group>"; };
 		24C7BD6C28C8AF7E0046F15C /* DeviceStorageDataSourceTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourceTester.swift; sourceTree = "<group>"; };
 		24C7BD6E28C9F2C80046F15C /* DeviceStorageDataSourceRegularTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStorageDataSourceRegularTests.swift; sourceTree = "<group>"; };
@@ -801,6 +803,7 @@
 				24C7BD7028CA01520046F15C /* DeviceStorageDataSourcePrefixTests.swift */,
 				24C7BD7228CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift */,
 				24C7BD7428CA11B30046F15C /* TimedCacheDataSourceTests.swift */,
+				003485D428E4592A0045CC27 /* DelayedMainQueueExecutorTests.swift */,
 			);
 			path = HarmonyTests;
 			sourceTree = "<group>";
@@ -1813,6 +1816,7 @@
 				D2067A40285C618600A1047E /* CacheRepositoryTests.swift in Sources */,
 				24C7BD6B28C793980046F15C /* FileSystemStorageDataSourceTests.swift in Sources */,
 				D28C13F3285B090500E4F2CA /* FutureTests.swift in Sources */,
+				003485D528E4592A0045CC27 /* DelayedMainQueueExecutorTests.swift in Sources */,
 				D2067A4A285C64AD00A1047E /* InMemoryDataSourceTests.swift in Sources */,
 				24C7BD7528CA11B30046F15C /* TimedCacheDataSourceTests.swift in Sources */,
 				24C7BD7328CA01C40046F15C /* DeviceStorageDataSourceRootKeyTests.swift in Sources */,

--- a/Sources/Harmony/Future/Executor/DirectExecutor.swift
+++ b/Sources/Harmony/Future/Executor/DirectExecutor.swift
@@ -34,7 +34,58 @@ public class DirectExecutor : Executor {
     }
 }
 
-///
+public final class DelayedMainQueueExecutor: MainDirectExecutor, DelayedExecutor {
+    
+    private let overrideDelay: Bool
+    
+    public init(overrideDelay: Bool = false) {
+        self.overrideDelay = overrideDelay
+    }
+        
+    public func submit(after: DispatchTime, _ closure: @escaping (@escaping () -> Void) -> Void) {
+        if self.overrideDelay {
+            self.submit(closure)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: after) {
+                self.executing = true
+                let sempahore = DispatchSemaphore(value: 0)
+                closure { sempahore.signal() }
+                sempahore.wait()
+                self.executing = false
+            }
+        }
+    }
+    
+    @discardableResult public func submit<T>(after: DispatchTime, _ closure: @escaping (FutureResolver<T>) throws -> Void) -> Future<T> {
+        let future = Future<T>()
+        self.submit(after: after) { end in
+            future.onSet {
+                end()
+            }
+            // Wrapping the closure with a try/catch to set errors automatically
+            do {
+                let resolver = FutureResolver(future)
+                try closure(resolver)
+            } catch (let error) {
+                future.set(error)
+            }
+        }
+        return future.toFuture() // Creating a new future to avoid a duplicate call to onSet to the same future
+    }
+    
+    /// Submits a closure for its execution.
+    ///
+    /// - Parameter closure: The closure to be executed. An error can be thrown.
+    /// - Returns: A future wrapping the error, if thrown.
+    @discardableResult public func submit(after: DispatchTime, _ closure:  @escaping () throws -> Void) -> Future<Void> {
+        return self.submit(after: after) { resolver in
+            try closure()
+            resolver.set()
+        }
+    }
+}
+
+//
 /// Executes on the main queue asynchronously.
 /// However, if the submit is called in the main thread, the submitted closure is directly called as in a DirectExecutor.
 ///

--- a/Sources/Harmony/Future/Executor/Executor.swift
+++ b/Sources/Harmony/Future/Executor/Executor.swift
@@ -33,6 +33,27 @@ public protocol Executor {
     func submit(_ closure: @escaping (@escaping () -> Void) -> Void)
 }
 
+///
+/// Refined type of Executor that delays execution of a closure
+///
+public protocol DelayedExecutor: Executor {
+    
+    /// Submits a closure for execution later in time
+    /// - Parameters:
+    ///   - after: amount of time elapsed before the closure gets executed
+    ///   - closure: The code to be executed. The closure must call its subclosure after completing (either sync or async)
+    /// - Returns: Nothing (Void)
+    func submit(after: DispatchTime, _ closure: @escaping (@escaping () -> Void) -> Void)
+
+    /// Submits a closure for execution later in time
+    /// - Parameters:
+    ///   - after: amount of time elapsed before the closure gets executed
+    ///   - closure: The code to be executed. The closure must call its subclosure after completing (either sync or async)
+    /// - Returns: Nothing (Void)
+    @discardableResult
+    func submit(after: DispatchTime, _ closure:  @escaping () throws -> Void) -> Future<Void>
+}
+
 fileprivate let lock = NSLock()
 fileprivate var counter : Int = 0
 

--- a/Tests/HarmonyTests/DelayedMainQueueExecutorTests.swift
+++ b/Tests/HarmonyTests/DelayedMainQueueExecutorTests.swift
@@ -1,0 +1,61 @@
+//
+//  DirectExecutorTests.swift
+//  HarmonyTests
+//
+//  Created by Borja Arias Drake on 21.09.2022..
+//
+
+import XCTest
+import Nimble
+import Harmony
+
+final class DelayedMainQueueExecutorTests: XCTestCase {
+
+    func test_submit() throws {
+        // Given
+        let executor = DelayedMainQueueExecutor()
+        let closureIsRun = XCTestExpectation()
+        
+        // When
+        executor.submit { resolver in
+            resolver.set()
+            XCTAssertTrue(Thread.isMainThread)
+            closureIsRun.fulfill()
+        }
+        
+        // Then
+        wait(for: [closureIsRun], timeout: 1)
+    }
+    
+    func test_submit_with_delay_overriding_delay() throws {
+        // Given
+        let executor = DelayedMainQueueExecutor(overrideDelay: true)
+        let closureIsRun = XCTestExpectation()
+        
+        // When
+        executor.submit(after: .now() + 2) { end in
+            end()
+            XCTAssertTrue(Thread.isMainThread)
+            closureIsRun.fulfill()
+        }
+        
+        // Then
+        wait(for: [closureIsRun], timeout: 1)
+    }
+    
+    func test_submit_with_delay_without_overriding() throws {
+        // Given
+        let executor = DelayedMainQueueExecutor()
+        let closureIsRun = XCTestExpectation()
+        
+        // When
+        executor.submit(after: .now() + 0.5) { end in
+            end()
+            XCTAssertTrue(Thread.isMainThread)
+            closureIsRun.fulfill()
+        }
+        
+        // Then
+        wait(for: [closureIsRun], timeout: 0.75)
+    }
+}


### PR DESCRIPTION
**Rational:** 
Some UI-related classes like presenters, need to send commands to the view with certain delay. This was implemented in a project and now is brought to Harmony. 

**Implementation details:** 
- The goal is to base the solution on the existing concept of an executor.
- There's a new protocol called `DelayedExecutor`, which inherits from `Executor`.
- There's a new class `DelayedMainQueueExecutor`, that executes a block of code in the main thread after a delay.

**Testing** 
- The pull request contains unit tests.
- The work has been tested in the original project that initiated this task.

**Asana task link**:
https://app.asana.com/0/1109863238977521/1202904831384369/f
